### PR TITLE
permit setting/appending structures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,10 @@ impl FromStr for TomlVal {
             Value::try_from(v).unwrap()
         } else if let Ok(v) = f64::from_str(s) {
             Value::try_from(v).unwrap()
+        } else if s == "[]" {
+            Value::Array(toml_edit::Array::new())
+        } else if s == "{}" {
+            Value::InlineTable(toml_edit::InlineTable::new())
         } else {
             s.into()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -670,6 +670,60 @@ mod tests {
     }
 
     #[test]
+    fn tomlval_parser_handles_inline_tables() {
+        let quoted = r#""{}""#;
+        let tval = TomlVal::from_str(quoted).expect("conversion should work");
+        match tval.inner {
+            Value::String(s) => {
+                assert_eq!(*s.value(), "{}");
+            }
+            _ => {
+                eprintln!("{:?}", tval.inner);
+                assert!(false, "should have been a string");
+            }
+        }
+
+        let inty = "{}";
+        let tval2 = TomlVal::from_str(inty).expect("conversion should work");
+        match tval2.inner {
+            Value::InlineTable(t) => {
+                assert_eq!(t.len(), 0);  // It should be empty to start
+            }
+            _ => {
+                eprintln!("{:?}", tval2.inner);
+                assert!(false, "should have been an inline table");
+            }
+        }
+    }
+
+    #[test]
+    fn tomlval_parser_handles_inline_arrays() {
+        let quoted = r#""[]""#;
+        let tval = TomlVal::from_str(quoted).expect("conversion should work");
+        match tval.inner {
+            Value::String(s) => {
+                assert_eq!(*s.value(), "[]");
+            }
+            _ => {
+                eprintln!("{:?}", tval.inner);
+                assert!(false, "should have been a string");
+            }
+        }
+
+        let inty = "[]";
+        let tval2 = TomlVal::from_str(inty).expect("conversion should work");
+        match tval2.inner {
+            Value::Array(a) => {
+                assert_eq!(a.len(), 0);  // It should be empty to start
+            }
+            _ => {
+                eprintln!("{:?}", tval2.inner);
+                assert!(false, "should have been an array");
+            }
+        }
+    }
+
+    #[test]
     fn can_set_booleans() {
         let toml = include_str!("../fixtures/sample.toml");
         let mut doc = toml


### PR DESCRIPTION
Hello! Thank you for the tool, I noticed it wasn't possible to fully construct new complex structures.

I figured this could be done incrementally with minimal effort, using `{}` and `[]` as literal symbols bound to specific functionality:

```
$ tomato set    'tool.uv.sources.torch'          '[]'          pyproject.toml
$ tomato append 'tool.uv.sources.torch'          '{}'          pyproject.toml
$ tomato set    'tool.uv.sources.torch[0].index' 'pytorch-cpu' pyproject.toml
```

when applied to the following toml:

```toml
[project]
name = "beep"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.12"
dependencies = []

[tool.uv.sources]
torchvision = [
    { index = "pytorch-cpu", marker = "platform_system == 'Linux'" },
]
```

results in

```toml
[project]
name = "beep"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.12"
dependencies = [
    "requests>=2.32.3"
]

[tool.uv.sources]
torchvision = [
    { index = "pytorch-cpu", marker = "platform_system == 'Linux'" },
]
torch = [{ index = "pytorch-cpu" }]
```